### PR TITLE
gh actions: set arch explicitely

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: scheduler-plugins-controller
+          arch: amd64
           tags: ${{ env.RELEASE_VERSION}}
           dockerfiles: |
             ./build/controller/Dockerfile
@@ -70,6 +71,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: scheduler-plugins-kube-scheduler
+          arch: amd64
           tags: ${{ env.RELEASE_VERSION}}
           dockerfiles: |
             ./build/scheduler/Dockerfile


### PR DESCRIPTION
For some not yet fully understood reasons, the
buildah step cannot figure out the arch automatically.
Setting `amd64` explicitely is not wrong - is what we
need anyway - so we do it.

Signed-off-by: Francesco Romani <fromani@redhat.com>