### PR TITLE
gh actions: add buildah-specific Dockerfiles

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,8 +53,10 @@ jobs:
           image: scheduler-plugins-controller
           arch: amd64
           tags: ${{ env.RELEASE_VERSION}}
+          build-args: |
+            ARCH=amd64
           dockerfiles: |
-            ./build/controller/Dockerfile
+            ./build/controller/Dockerfile.k8staswg
 
       - name: push controller to quay
         id: push-controller-to-quay
@@ -73,8 +75,10 @@ jobs:
           image: scheduler-plugins-kube-scheduler
           arch: amd64
           tags: ${{ env.RELEASE_VERSION}}
+          build-args: |
+            ARCH=amd64
           dockerfiles: |
-            ./build/scheduler/Dockerfile
+            ./build/scheduler/Dockerfile.k8staswg
 
       - name: push scheduler to quay
         id: push-scheduler-to-quay

--- a/build/controller/Dockerfile.k8staswg
+++ b/build/controller/Dockerfile.k8staswg
@@ -1,0 +1,26 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG ARCH
+FROM golang:1.15.10 AS builder
+WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
+COPY . .
+
+ARG ARCH
+RUN make build-controller.$ARCH
+
+ARG ARCH
+FROM docker.io/$ARCH/alpine:3.12
+COPY --from=builder /go/src/sigs.k8s.io/scheduler-plugins/bin/controller /bin/controller
+WORKDIR /bin
+CMD ["controller"]

--- a/build/scheduler/Dockerfile.k8staswg
+++ b/build/scheduler/Dockerfile.k8staswg
@@ -1,0 +1,27 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG ARCH
+FROM golang:1.15.10 AS builder
+WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
+COPY . .
+
+ARG ARCH
+ARG RELEASE_VERSION
+RUN RELEASE_VERSION=${RELEASE_VERSION} make build-scheduler.$ARCH
+
+ARG ARCH
+FROM $ARCH/alpine:3.12
+COPY --from=builder /go/src/sigs.k8s.io/scheduler-plugins/bin/kube-scheduler /bin/kube-scheduler
+WORKDIR /bin
+CMD ["kube-scheduler"]


### PR DESCRIPTION
We use buildah in our gh release flow (courtesy of redhat actions),
so we need some minor fixes in the Dockerfiles.
Create org-specific Dockerfiles until u/s catches up.

Signed-off-by: Francesco Romani <fromani@redhat.com>