### PR TITLE
build: correctly inject the version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: set extra environment variables
         run: |
             echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+            echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
             echo "GOPATH=$(pwd)/.." >> $GITHUB_ENV
 
       - name: unit-test
@@ -77,6 +78,7 @@ jobs:
           tags: ${{ env.RELEASE_VERSION}}
           build-args: |
             ARCH=amd64
+            VERSION=${{ env.VERSION }}
           dockerfiles: |
             ./build/scheduler/Dockerfile.k8staswg
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ RELEASE_CONTROLLER_IMAGE:=controller:$(RELEASE_VERSION)
 # The RELEASE_VERSION variable can have one of two formats:
 # v20201009-v0.18.800-46-g939c1c0 - automated build for a commit(not a tag) and also a local build
 # v20200521-v0.18.800             - automated build for a tag
-VERSION=$(shell echo $(RELEASE_VERSION) | awk -F - '{print $$2}')
+VERSION?=$(shell echo $(RELEASE_VERSION) | awk -F - '{print $$2}')
 
 .PHONY: all
 all: build

--- a/build/scheduler/Dockerfile.k8staswg
+++ b/build/scheduler/Dockerfile.k8staswg
@@ -17,8 +17,9 @@ WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
 
 ARG ARCH
+ARG VERSION
 ARG RELEASE_VERSION
-RUN RELEASE_VERSION=${RELEASE_VERSION} make build-scheduler.$ARCH
+RUN RELEASE_VERSION=${RELEASE_VERSION} VERSION=${VERSION} make build-scheduler.$ARCH
 
 ARG ARCH
 FROM $ARCH/alpine:3.12


### PR DESCRIPTION
In our github-based build flow, we don't inject correctly
the version when building the scheduler, leading to a DOA image
with the scheduler panicing on start:
```
panic: version string "" doesn't match expected regular expression: "^v(\d+\.\d+\.\d+)"

goroutine 1 [running]:
k8s.io/component-base/metrics.parseVersion(0x0, 0x0, 0x0, 0x0, 0x24a3137, 0x0, 0x2254874, 0xb, 0x0, 0x0, ...)
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/component-base/metrics/version_parser.go:47 +0x2c5
k8s.io/component-base/metrics.newKubeRegistry(0x0, 0x0, 0x0, 0x0, 0x24a3137, 0x0, 0x2254874, 0xb, 0x0, 0x0, ...)
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/component-base/metrics/registry.go:320 +0xfb
k8s.io/component-base/metrics.NewKubeRegistry(0x9, 0xc000194180)
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/component-base/metrics/registry.go:335 +0x7f
k8s.io/component-base/metrics/legacyregistry.init()
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/component-base/metrics/legacyregistry/registry.go:29 +0x26
[fromani@kronus ~]$ K logs -n tas-scheduler topology-aware-scheduler-69cd86d7f9-hlfsc
panic: version string "" doesn't match expected regular expression: "^v(\d+\.\d+\.\d+)"

goroutine 1 [running]:
k8s.io/component-base/metrics.parseVersion(0x0, 0x0, 0x0, 0x0, 0x24a3137, 0x0, 0x2254874, 0xb, 0x0, 0x0, ...)
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/component-base/metrics/version_parser.go:47 +0x2c5
k8s.io/component-base/metrics.newKubeRegistry(0x0, 0x0, 0x0, 0x0, 0x24a3137, 0x0, 0x2254874, 0xb, 0x0, 0x0, ...)
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/component-base/metrics/registry.go:320 +0xfb
k8s.io/component-base/metrics.NewKubeRegistry(0x9, 0xc000194180)
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/component-base/metrics/registry.go:335 +0x7f
k8s.io/component-base/metrics/legacyregistry.init()
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/component-base/metrics/legacyregistry/registry.go:29 +0x26
```

The root cause is a mismatch between how RELEASE_VERSION is provided.
The simplest (and u/s friendly) fix is to just inject VERSION alongside
RELEASE_VERSION.

Signed-off-by: Francesco Romani <fromani@redhat.com>