### PR TITLE
[WG] use golang 1.17 in the release flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v2
         id: go
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: verify modules
         run: go mod verify


### PR DESCRIPTION
From
https://github.com/k8stopologyawareschedwg/scheduler-plugins/runs/4312480475?check_suite_focus=true

we see
```
vendor/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics.go:21:2: cannot find package "." in:
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/io/fs
```

So we need golang >= 1.17 - like kube is requiring anyway

Signed-off-by: Francesco Romani <fromani@redhat.com>