### PR TITLE
[WG] update golang for containerized builds

### DIFF
--- a/build/controller/Dockerfile.k8staswg
+++ b/build/controller/Dockerfile.k8staswg
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.15.10 AS builder
+FROM golang:1.16.10 AS builder
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
 

--- a/build/scheduler/Dockerfile.k8staswg
+++ b/build/scheduler/Dockerfile.k8staswg
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.15.10 AS builder
+FROM golang:1.16.10 AS builder
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
 


### PR DESCRIPTION
We need to bump the golang version we use to do the containerized
builds.

Signed-off-by: Francesco Romani <fromani@redhat.com>