### PR TITLE
[WG] fix missing Dockerfile

### DIFF
--- a/build/controller/Dockerfile.k8staswg
+++ b/build/controller/Dockerfile.k8staswg
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.16.10 AS builder
+FROM golang:1.19 as builder
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
 


### PR DESCRIPTION
The update to golang 1.19 was partial, fix the missing part